### PR TITLE
Remove Cluster/Region ENV vars during build

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -19,15 +19,9 @@ RUN if [[ "$BUILD_ARCH" == "arm64v8" ]] ; then curl -LO https://storage.googleap
 RUN chmod +x ./kubectl
 RUN mv ./kubectl /usr/local/bin
 
-ARG CLUSTER_OCID
-ARG REGION
-
 COPY .oci/* /root/.oci/
 COPY ./generate_config.sh /root/
 RUN chmod +x /root/generate_config.sh
-
-ENV CLUSTER_OCID=$CLUSTER_OCID
-ENV REGION=$REGION
 
 # Finally, run the generate config step so we can do that as we start
 # CMD ["./root/generate_config.sh", ";", "/bin/bash"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 build:
-	docker build -t operator-tool ./Docker --build-arg CLUSTER_OCID="${CLUSTER_OCID}" --build-arg REGION=${REGION}
+	docker build -t operator-tool ./Docker 
 
 build-arm:
-	docker build -t operator-tool ./Docker --build-arg CLUSTER_OCID="${CLUSTER_OCID}" --build-arg REGION="${REGION}" --build-arg BUILD_ARCH="arm64v8"
+	docker build -t operator-tool ./Docker --build-arg BUILD_ARCH="arm64v8"
 


### PR DESCRIPTION
Rather than feeding this in during build, we should supply it when running the container